### PR TITLE
Update Base Roulant to handle negative speed command from CAN

### DIFF
--- a/elec-soft/base_roulant/Base_Roulant/base_roulant.c
+++ b/elec-soft/base_roulant/Base_Roulant/base_roulant.c
@@ -45,6 +45,20 @@ float dkRight;
 float ikLeft;
 float ikRight;
 
+uint8_t enable_flag = 0;
+
+/* ID of STM for CAN */
+/* 
+ * CAN ID of the STM32 <-- CHANGE THIS ACCORDING TO THE STM32
+ * ID for CDF2024 :
+ * 2 : Base Roulante (Left + Right)
+ * 3 : Base Roulante 2 (Front + Rear)
+ */
+/* !!!!!!!!!!!!!!!!! */
+#define CAN_ID_STM 3
+
+/*********************/
+
 /**
  * @brief Error Handler for the base roulant
  *
@@ -64,19 +78,25 @@ void BR_init(TIM_HandleTypeDef * TIM_Regulate,TIM_HandleTypeDef * TIM_Motor_Left
     Motor_Init(&motor_left, DIR_Port_Left, DIR_Pin_Left, TIM_Motor_Left, TIM_Channel_Motor_Left);
     Motor_Init(&motor_right, DIR_Port_Right, DIR_Pin_Right, TIM_Motor_Right, TIM_Channel_Motor_Right);
     Timer_Regulate = TIM_Regulate;
+    BR_startAllMotors();
 	/* Init CAN interface */
-    CAN_initInterface(hfdcan, 2);
+    CAN_initInterface(hfdcan, CAN_ID_STM);
     CAN_filterConfig();
     CAN_setReceiveCallback(BR_executeCommandFromCAN);
     CAN_start();
+    CAN_sendBackPing(CAN_ID_MASTER);
     HAL_Delay(100);
 }
 
 void BR_startAllMotors(void){
+	enable_flag = 1;
     Motor_Start(&motor_left);
     Motor_Start(&motor_right);
+    Motor_Set_Direction(&motor_left, MOTOR_DIRECTION_CW);
+    Motor_Set_Direction(&motor_right, MOTOR_DIRECTION_CCW);
+
     HAL_TIM_Base_Start_IT(Timer_Regulate);
-	BR_setSpeed(0.0);
+	BR_setSpeed(BR_MOTOR_BROADCAST,0.0);
 	regulatedSpeedLeft=0.0;
 	regulatedSpeedRight=0.0;
 	oldSpeedLeft = 0.0;
@@ -90,7 +110,8 @@ void BR_startAllMotors(void){
 }
 
 void BR_stopAllMotors(void){
-	BR_setSpeed(0.0);
+	enable_flag = 0;
+	BR_setSpeed(BR_MOTOR_BROADCAST,0.0);
 	regulatedSpeedLeft=0.0;
 	regulatedSpeedRight=0.0;
 	oldSpeedLeft = 0.0;
@@ -118,6 +139,10 @@ void BR_setDirection(BR_Motor_ID_t motor, BR_Direction_t direction){
     else if (motor == BR_MOTOR_RIGHT){
         Motor_Set_Direction(&motor_right, direction);
     } 
+	else if (motor == BR_MOTOR_BROADCAST){
+		Motor_Set_Direction(&motor_left, direction);
+		Motor_Set_Direction(&motor_right, direction);
+	}
     else {
         /* Error handler to add*/
         BR_errorHandler(BR_ERROR_MOTOR_ID);
@@ -137,6 +162,10 @@ void BR_setPWM(BR_Motor_ID_t motor, uint8_t pwm){
     else if (motor == BR_MOTOR_RIGHT){
         Motor_Set_Speed(&motor_right, pwm);
     } 
+	else if (motor == BR_MOTOR_BROADCAST){
+		Motor_Set_Speed(&motor_left, pwm);
+		Motor_Set_Speed(&motor_right, pwm);
+	}
     else {
         /* Error handler to add*/
         BR_errorHandler(BR_ERROR_MOTOR_ID);
@@ -204,11 +233,12 @@ float BR_getDistance(BR_Motor_ID_t motor){
 }
 
 
-void BR_setSpeed(float speed) {
-	if(speed < 0.0)
-	{
-		BR_stopAllMotors();
-		return;
+void BR_setSpeed(BR_Motor_ID_t motor,float speed) {
+	if (speed >= 0.0){
+		BR_setDirection(motor, BR_DIRECTION_CW);
+	} else {
+		BR_setDirection(motor, BR_DIRECTION_CCW);
+		speed = -speed;
 	}
 
 	if(speed > BR_SPEED_LIMIT_MM_S)
@@ -216,71 +246,90 @@ void BR_setSpeed(float speed) {
 		speed = BR_SPEED_LIMIT_MM_S;
 	}
 
-	targetSpeedLeft = speed;
-	targetSpeedRight = speed;
+	switch(motor){
+		case BR_MOTOR_LEFT:
+			targetSpeedLeft = speed;
+			BR_setPWM(BR_MOTOR_LEFT, (int)(targetSpeedLeft * SPEED_TO_PWM_CONVERSION));
+			break;
+		case BR_MOTOR_RIGHT:
+			targetSpeedRight = speed;
+			BR_setPWM(BR_MOTOR_RIGHT, (int)(targetSpeedRight * SPEED_TO_PWM_CONVERSION));
+			break;
+		case BR_MOTOR_BROADCAST:
+			targetSpeedLeft = speed;
+			targetSpeedRight = speed;
+			break;
+		default:
+			break;
+	}
 }
 
 void BR_regulateSpeed(void){
-    float currentSpeedLeft = BR_getSpeed(BR_MOTOR_LEFT);
-    float currentSpeedRight = BR_getSpeed(BR_MOTOR_RIGHT);
+    float currentSpeedLeft;
+    float currentSpeedRight;
     float errorLeft;
     float errorRight;
 
-	if((currentSpeedLeft < 0.0) ||(currentSpeedRight < 0.0))
-	{	
-        //detect invalid speed readings
-		currentSpeedLeft = 0.0;
-		currentSpeedRight = 0.0;
-	}
+    if (enable_flag != 0){
 
-	errorLeft = targetSpeedLeft - currentSpeedLeft;
-	errorRight = targetSpeedRight - currentSpeedRight;
+		currentSpeedLeft = BR_getSpeed(BR_MOTOR_LEFT);
+		currentSpeedRight = BR_getSpeed(BR_MOTOR_RIGHT);
+		if((currentSpeedLeft < 0.0) ||(currentSpeedRight < 0.0))
+		{
+			//detect invalid speed readings
+			currentSpeedLeft = 0.0;
+			currentSpeedRight = 0.0;
+		}
 
-	dkLeft = BR_SPEED_CORRECTOR_KPD*(dkLeft - currentSpeedLeft + oldSpeedLeft);
-	ikLeft = ikLeft + BR_SPEED_CORRECTOR_KPI*(errorLeft + applySpeedLeft - regulatedSpeedLeft);
-	if(errorLeft > BR_SPEED_CORRECTOR_THRESHOLD || errorLeft < -BR_SPEED_CORRECTOR_THRESHOLD)   //error margin
-	{
-		regulatedSpeedLeft =  ikLeft + BR_SPEED_CORRECTOR_KP*errorLeft + dkLeft;
-	}
+		errorLeft = targetSpeedLeft - currentSpeedLeft;
+		errorRight = targetSpeedRight - currentSpeedRight;
 
-	dkRight = BR_SPEED_CORRECTOR_KPD*(dkRight - currentSpeedRight + oldSpeedRight);
-	ikRight = ikRight + BR_SPEED_CORRECTOR_KPI*(errorRight + applySpeedRight - regulatedSpeedRight);
-	if(errorRight > BR_SPEED_CORRECTOR_THRESHOLD || errorRight < -BR_SPEED_CORRECTOR_THRESHOLD)
-	{
-		regulatedSpeedRight = ikRight + BR_SPEED_CORRECTOR_KP*errorRight + dkRight;
-	}
+		dkLeft = BR_SPEED_CORRECTOR_KPD*(dkLeft - currentSpeedLeft + oldSpeedLeft);
+		ikLeft = ikLeft + BR_SPEED_CORRECTOR_KPI*(errorLeft + applySpeedLeft - regulatedSpeedLeft);
+		if(errorLeft > BR_SPEED_CORRECTOR_THRESHOLD || errorLeft < -BR_SPEED_CORRECTOR_THRESHOLD)   //error margin
+		{
+			regulatedSpeedLeft =  ikLeft + BR_SPEED_CORRECTOR_KP*errorLeft + dkLeft;
+		}
+
+		dkRight = BR_SPEED_CORRECTOR_KPD*(dkRight - currentSpeedRight + oldSpeedRight);
+		ikRight = ikRight + BR_SPEED_CORRECTOR_KPI*(errorRight + applySpeedRight - regulatedSpeedRight);
+		if(errorRight > BR_SPEED_CORRECTOR_THRESHOLD || errorRight < -BR_SPEED_CORRECTOR_THRESHOLD)
+		{
+			regulatedSpeedRight = ikRight + BR_SPEED_CORRECTOR_KP*errorRight + dkRight;
+		}
 
 
-    // Apply regulated speed to motors
-	if(regulatedSpeedLeft < 0.0){
-		applySpeedLeft = 0.0;
+		// Apply regulated speed to motors
+		if(regulatedSpeedLeft < 0.0){
+			applySpeedLeft = 0.0;
+		}
+		else if(regulatedSpeedLeft > BR_SPEED_LIMIT_MM_S){
+			applySpeedLeft = BR_SPEED_LIMIT_MM_S;
+		}
+		else
+		{
+			applySpeedLeft = regulatedSpeedLeft;
+		}
+
+		if(regulatedSpeedRight < 0.0){
+			applySpeedRight = 0.0;
+		}
+		else if(regulatedSpeedRight > BR_SPEED_LIMIT_MM_S){
+			applySpeedRight = BR_SPEED_LIMIT_MM_S;
+		}
+		else
+		{
+			applySpeedRight = regulatedSpeedRight;
+		}
+
+		BR_setPWM(BR_MOTOR_LEFT, (int)(applySpeedLeft * SPEED_TO_PWM_CONVERSION));
+		BR_setPWM(BR_MOTOR_RIGHT, (int)(applySpeedRight * SPEED_TO_PWM_CONVERSION));
+
+
+	   // Update old speed
+		oldSpeedLeft = currentSpeedLeft;
+		oldSpeedRight = currentSpeedRight;
     }
-	else if(regulatedSpeedLeft > BR_SPEED_LIMIT_MM_S){
-		applySpeedLeft = BR_SPEED_LIMIT_MM_S;
-    }
-	else
-	{
-		applySpeedLeft = regulatedSpeedLeft;
-	}
-
-	if(regulatedSpeedRight < 0.0){
-		applySpeedRight = 0.0;
-    }
-	else if(regulatedSpeedRight > BR_SPEED_LIMIT_MM_S){
-		applySpeedRight = BR_SPEED_LIMIT_MM_S;
-    }
-	else
-	{
-		applySpeedRight = regulatedSpeedRight;
-	}
-
-	BR_setPWM(BR_MOTOR_LEFT, (int)(applySpeedLeft * SPEED_TO_PWM_CONVERSION));
-	BR_setPWM(BR_MOTOR_RIGHT, (int)(applySpeedRight * SPEED_TO_PWM_CONVERSION));
-
-
-   // Update old speed
-	oldSpeedLeft = currentSpeedLeft;
-	oldSpeedRight = currentSpeedRight;
 }
 
 
@@ -305,6 +354,7 @@ void BR_executeCommandFromCAN(void){
 	uint8_t * cmd = CAN_getRXData();
     uint8_t dataToRaspi[8] = {0,0,0,0,0,0,0,0};
     float speed;
+    BR_Motor_ID_t idMotor;
 	switch (cmd[0]){
 		case 0:
 			BR_stopAllMotors();
@@ -316,15 +366,17 @@ void BR_executeCommandFromCAN(void){
 			BR_startAllMotors();
 			break;
 		case 3:
-			speed = (float)((cmd[2] << 8) + cmd[3]) / 10.0;
-			BR_setSpeed(speed);  // For test only, change to setSpeed after
-		  break;
+			idMotor = cmd[1];
+			speed = (float)((cmd[2] << 24) + (cmd[3]<<16) + (cmd[4]<<8) + cmd[5]) / 10.0;
+			BR_setSpeed(idMotor,speed);
+			break;
 		case 4:
-			speed = (float)((cmd[2] << 8) + cmd[3]) / 10.0;
-			BR_setSpeed(speed);  // For test only, change to setSpeed after
+			idMotor = cmd[1];
+			speed = (float)((cmd[2] << 24) + (cmd[3]<<16) + (cmd[4]<<8) + cmd[5]) / 10.0;
+			BR_setSpeed(idMotor,speed);
 			break;
 		case 5:
-			BR_setDirection(cmd[1], cmd[2]);
+			//BR_setDirection(cmd[1], cmd[2]);
 			break;
 		case 6:
 			dataToRaspi[0] = 0x05;
@@ -333,7 +385,9 @@ void BR_executeCommandFromCAN(void){
 			dataToRaspi[2] = (speed && 0xFF00);
 			dataToRaspi[3] = (speed && 0x00FF);
 			CAN_send(dataToRaspi, 1, CAN_ID_MASTER);
-		  break;
+			break;
+		default :
+			break;
 	}
 }
 

--- a/elec-soft/base_roulant/Base_Roulant/base_roulant.h
+++ b/elec-soft/base_roulant/Base_Roulant/base_roulant.h
@@ -3,8 +3,8 @@
  * @author 	Triet NGUYEN (tr_nguye@insa-toulouse.fr)
  * 			Huong-Cam TANG (hctang@insa-toulouse.fr)
  * @brief Header file for the base roulant module
- * @version 0.1
- * @date 2021-03-14
+ * @version 1.0
+ * @date 01-05-2024
  * 
  * @copyright Copyright (c) 2023
  * 
@@ -46,7 +46,8 @@ extern "C" {
 /* ---------------------------Exported Types --------------------------------- */
 typedef enum {
     BR_MOTOR_LEFT = 0,
-    BR_MOTOR_RIGHT = 1
+    BR_MOTOR_RIGHT = 1,
+	BR_MOTOR_BROADCAST = 255,
 } BR_Motor_ID_t;
 
 typedef enum {
@@ -136,9 +137,10 @@ void BR_setPWM(BR_Motor_ID_t motor, uint8_t pwm);
 /**
  * @brief Set the target speed of the motor
  * 
+ * @param motor ID of the motor
  * @param speed Speed of the motor in mm/s
  */
-void BR_setSpeed(float speed);
+void BR_setSpeed(BR_Motor_ID_t motor,float speed);
 
 /**
  * @brief Regulate the speed of the motor

--- a/elec-soft/base_roulant/Core/Src/main.c
+++ b/elec-soft/base_roulant/Core/Src/main.c
@@ -70,7 +70,7 @@ static void MX_FDCAN1_Init(void);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
-
+uint8_t dataTest[8] = {1,2,3,4,5,6,7,8};
 /* USER CODE END 0 */
 
 /**
@@ -110,6 +110,7 @@ int main(void)
   BR_init(&htim1 ,&htim2, TIM_CHANNEL_MOTOR_LEFT, &htim2, TIM_CHANNEL_MOTOR_RIGHT, DIR_MOTOR_1_GPIO_Port, DIR_MOTOR_1_Pin, DIR_MOTOR_2_GPIO_Port, DIR_MOTOR_2_Pin, &htim3, &htim4, &hfdcan1);
 
 
+
   //BR_setPWM(BR_MOTOR_LEFT, 50);
   //BR_setPWM(BR_MOTOR_RIGHT, 50);
 //  HAL_Delay(10000);
@@ -131,9 +132,11 @@ int main(void)
   /* USER CODE BEGIN WHILE */
   while (1)
   {
-	  s_left = BR_getSpeed(BR_MOTOR_LEFT);
-	  s_right = BR_getSpeed(BR_MOTOR_RIGHT);
+	  //s_left = BR_getSpeed(BR_MOTOR_LEFT);
+	  //s_right = BR_getSpeed(BR_MOTOR_RIGHT);
 	  BR_getCMDfromCAN();
+	  //CAN_sendBackPing(CAN_ID_MASTER);
+	  //CAN_send(dataTest, 0, 1);
 	  HAL_Delay(10);
     /* USER CODE END WHILE */
 

--- a/elec-soft/base_roulant/can_interface_stm32/can_stm32.c
+++ b/elec-soft/base_roulant/can_interface_stm32/can_stm32.c
@@ -137,8 +137,8 @@ uint8_t CAN_decodeIDSrc(void)
 }
 
 void CAN_sendBackPing(uint8_t destID) {
-	uint8_t data[8] = {1,0,0,0,0,0,0,0};
-	CAN_send(data, 1, CAN_ID_STM);
+	uint8_t data[8] = {1,0,1,0,1,0,1,0};
+	CAN_send(data, destID, CAN_ID_STM);
 }
 
 void CAN_errorHandler(void)


### PR DESCRIPTION
- Base Roulant can now handle negative speed send by Raspberry
   Speed > 0 : Clock-wise
   Speed < 0 : Counter clock-wise
- Regulation loop is active, to deactivate, comment the BR_regulateSpeed() in HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) --> line 344, file base_roulant.c
   